### PR TITLE
Add data_dir config option for custom PrismLauncher directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,34 @@ Press `/` to enter search mode. Type to filter the list incrementally. Press `En
 
 ## Configuration
 
-prism-tui reads its configuration from PrismLauncher's data directory:
+### PrismLauncher Data Directory
 
-- **Linux**: `~/.local/share/PrismLauncher/`
+prism-tui automatically detects your PrismLauncher data directory:
+
+- **Linux**: `~/.local/share/PrismLauncher/` or Flatpak location
 - **macOS**: `~/Library/Application Support/PrismLauncher/`
 - **Windows**: `%APPDATA%/PrismLauncher/`
 
-No additional configuration is required.
+For custom or portable installations, you can override the data directory in two ways (checked in this order):
+
+1. **Environment variable**: `PRISMLAUNCHER_DATA=/path/to/data prism-tui`
+2. **Config file**: Set `data_dir` in the config (see below)
+
+### Config File
+
+prism-tui stores its settings in a TOML config file:
+
+- **Linux**: `~/.config/prism-tui/config.toml`
+- **macOS**: `~/Library/Application Support/prism-tui/config.toml`
+- **Windows**: `%APPDATA%\prism-tui\config.toml`
+
+```toml
+default_sort = "Last Played"
+sort_ascending = true
+data_dir = "~/Games/PrismLauncher"  # optional, overrides auto-detection
+```
+
+Sort and sort-direction preferences are saved automatically. The `data_dir` option supports `~` tilde expansion.
 
 ## Architecture
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -203,7 +203,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(config: PrismConfig) -> Result<Self> {
+    pub fn new(config: PrismConfig, app_config: AppConfig) -> Result<Self> {
         use crate::data::{load_accounts, load_groups, load_instances};
 
         let instances_dir = config.instances_dir();
@@ -212,8 +212,6 @@ impl App {
         let accounts = load_accounts(&config.accounts_path())?;
 
         let active_account = accounts.iter().find(|a| a.is_active).cloned();
-
-        let app_config = AppConfig::load();
 
         let sort_mode = app_config.default_sort_mode();
         let sort_ascending = app_config.sort_ascending;

--- a/src/data/app_config.rs
+++ b/src/data/app_config.rs
@@ -84,7 +84,8 @@ impl AppConfig {
 }
 
 fn expand_tilde(path: &str) -> PathBuf {
-    if let Some(rest) = path.strip_prefix("~/") {
+    let rest = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\"));
+    if let Some(rest) = rest {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest);
         }

--- a/src/data/app_config.rs
+++ b/src/data/app_config.rs
@@ -89,10 +89,10 @@ fn expand_tilde(path: &str) -> PathBuf {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest);
         }
-    } else if path == "~" {
-        if let Some(home) = dirs::home_dir() {
-            return home;
-        }
+    } else if path == "~"
+        && let Some(home) = dirs::home_dir()
+    {
+        return home;
     }
     PathBuf::from(path)
 }

--- a/src/data/app_config.rs
+++ b/src/data/app_config.rs
@@ -9,6 +9,8 @@ pub struct AppConfig {
     pub default_sort: String,
     #[serde(default = "default_true")]
     pub sort_ascending: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_dir: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -24,6 +26,7 @@ impl Default for AppConfig {
         Self {
             default_sort: default_sort(),
             sort_ascending: true,
+            data_dir: None,
         }
     }
 }
@@ -65,6 +68,10 @@ impl AppConfig {
         }
     }
 
+    pub fn resolved_data_dir(&self) -> Option<PathBuf> {
+        self.data_dir.as_ref().map(|p| expand_tilde(p))
+    }
+
     pub fn default_sort_mode(&self) -> SortMode {
         match self.default_sort.as_str() {
             "Name" => SortMode::Name,
@@ -74,4 +81,17 @@ impl AppConfig {
             _ => SortMode::LastPlayed,
         }
     }
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    } else if path == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    PathBuf::from(path)
 }

--- a/src/data/config.rs
+++ b/src/data/config.rs
@@ -45,6 +45,10 @@ pub fn find_prism_data_dir(config_data_dir: Option<PathBuf>) -> Result<PathBuf> 
         if path.exists() {
             return Ok(path);
         }
+        return Err(PrismError::Config(format!(
+            "PRISMLAUNCHER_DATA directory does not exist: {}",
+            path.display()
+        )));
     }
 
     // 2. Config file data_dir

--- a/src/data/config.rs
+++ b/src/data/config.rs
@@ -38,8 +38,8 @@ impl PrismConfig {
     }
 }
 
-pub fn find_prism_data_dir() -> Result<PathBuf> {
-    // Check environment variable first
+pub fn find_prism_data_dir(config_data_dir: Option<PathBuf>) -> Result<PathBuf> {
+    // 1. Check environment variable first
     if let Ok(path) = env::var("PRISMLAUNCHER_DATA") {
         let path = PathBuf::from(path);
         if path.exists() {
@@ -47,7 +47,18 @@ pub fn find_prism_data_dir() -> Result<PathBuf> {
         }
     }
 
-    // Standard location
+    // 2. Config file data_dir
+    if let Some(path) = config_data_dir {
+        if path.exists() {
+            return Ok(path);
+        }
+        return Err(PrismError::Config(format!(
+            "Configured data_dir does not exist: {}",
+            path.display()
+        )));
+    }
+
+    // 3. Standard platform location
     if let Some(data_dir) = dirs::data_dir() {
         let standard = data_dir.join("PrismLauncher");
         if standard.exists() {
@@ -55,7 +66,7 @@ pub fn find_prism_data_dir() -> Result<PathBuf> {
         }
     }
 
-    // Flatpak location (Linux only)
+    // 4. Flatpak location (Linux only)
     #[cfg(target_os = "linux")]
     {
         if let Some(home) = dirs::home_dir() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod view;
 
 use app::App;
 use color_eyre::Result;
-use data::{PrismConfig, find_prism_data_dir};
+use data::{AppConfig, PrismConfig, find_prism_data_dir};
 use message::Message;
 use std::time::Duration;
 use tui::{Event, EventStream, Terminal};
@@ -19,9 +19,10 @@ use tui::{Event, EventStream, Terminal};
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
-    let data_dir = find_prism_data_dir()?;
+    let app_config = AppConfig::load();
+    let data_dir = find_prism_data_dir(app_config.resolved_data_dir())?;
     let config = PrismConfig::load(&data_dir)?;
-    let mut app = App::new(config)?;
+    let mut app = App::new(config, app_config)?;
     let mut terminal = Terminal::new()?;
     let mut events = EventStream::new(Duration::from_millis(250));
 


### PR DESCRIPTION
## Summary

- Add `data_dir` option to `~/.config/prism-tui/config.toml` for users with non-standard PrismLauncher installations (portable installs, custom paths)
- Support tilde expansion (`~/`, `~\`) on all platforms
- Error explicitly when a user-configured path (env var or config) doesn't exist instead of silently falling through

## Changes

- **`src/data/app_config.rs`** — Added `data_dir: Option<String>` field, `resolved_data_dir()` method, and `expand_tilde()` helper
- **`src/data/config.rs`** — `find_prism_data_dir()` now accepts a config override with priority: env var > config file > platform default > Flatpak. Both env var and config error explicitly on missing paths
- **`src/main.rs`** — Load `AppConfig` before data dir detection and pass it through
- **`src/app.rs`** — `App::new()` accepts `AppConfig` parameter instead of loading it internally
- **`README.md`** — Document config file location, `data_dir` option, and data directory detection order

## Example Config

```toml
default_sort = "Last Played"
sort_ascending = true
data_dir = "~/Games/PrismLauncher"
```

## Test plan

- [ ] `cargo build` — no warnings
- [ ] Run without `data_dir` set — existing auto-detection works unchanged
- [ ] Add `data_dir = "/some/valid/path"` to config — app uses that path
- [ ] Add `data_dir = "/nonexistent"` — app shows config error
- [ ] Set both env var and config `data_dir` — env var wins
- [ ] Set env var to nonexistent path — app shows error instead of falling through

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Added configurable `data_dir` option to support non-standard PrismLauncher installations (portable installs, custom paths). The implementation follows a clear priority chain: environment variable > config file > platform default > Flatpak location.

Key improvements:
- Tilde expansion (`~/`, `~\`) works cross-platform via `expand_tilde()` helper in `src/data/app_config.rs:86`
- Explicit error messages when user-configured paths don't exist instead of silent fallthrough
- Config loaded early in `main.rs` to pass resolved path through initialization chain
- `App::new()` signature changed to accept `AppConfig` parameter for cleaner dependency flow
- Documentation clearly explains config file location and data directory detection order
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- Well-structured implementation with clear separation of concerns, proper error handling for edge cases, and comprehensive documentation. The tilde expansion logic correctly handles both Unix and Windows path formats, and the priority chain is well-defined.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/data/app_config.rs | Added `data_dir` field with tilde expansion via `expand_tilde()` helper and `resolved_data_dir()` method |
| src/data/config.rs | Modified `find_prism_data_dir()` to accept config override with explicit error handling for missing paths |
| src/main.rs | Loads `AppConfig` before data dir detection and passes resolved path to `find_prism_data_dir()` |
| src/app.rs | Updated `App::new()` to accept `AppConfig` parameter instead of loading internally |
| README.md | Documented config file location, `data_dir` option, and data directory detection priority order |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: main.rs] --> B[Load AppConfig]
    B --> C[Call resolved_data_dir]
    C --> D[expand_tilde on data_dir if set]
    D --> E[find_prism_data_dir]
    
    E --> F{PRISMLAUNCHER_DATA<br/>env var set?}
    F -->|Yes| G{Path exists?}
    G -->|Yes| H[Return env var path]
    G -->|No| I[Error: env var<br/>path not found]
    
    F -->|No| J{Config data_dir<br/>provided?}
    J -->|Yes| K{Path exists?}
    K -->|Yes| L[Return config path]
    K -->|No| M[Error: config<br/>path not found]
    
    J -->|No| N{Standard platform<br/>path exists?}
    N -->|Yes| O[Return standard path]
    N -->|No| P{Flatpak path<br/>exists? Linux only}
    P -->|Yes| Q[Return Flatpak path]
    P -->|No| R[Error: DataDirNotFound]
    
    H --> S[Initialize App]
    L --> S
    O --> S
    Q --> S
```

<sub>Last reviewed commit: 73b75fe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->