### PR TITLE
feat: add separate instances_dir config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,14 @@ prism-tui stores its settings in a TOML config file:
 ```toml
 default_sort = "Last Played"
 sort_ascending = true
-data_dir = "~/Games/PrismLauncher"  # optional, overrides auto-detection
+data_dir = "~/Games/PrismLauncher"          # optional, overrides auto-detection
+instances_dir = "/mnt/ssd/mc-instances"     # optional, overrides instances path
 ```
 
-Sort and sort-direction preferences are saved automatically. The `data_dir` option supports `~` tilde expansion.
+Sort and sort-direction preferences are saved automatically. Both `data_dir` and `instances_dir` support `~` tilde expansion.
+
+- `data_dir` overrides the root PrismLauncher directory (affects accounts, logs, launcher config, and instances).
+- `instances_dir` overrides only the instances path, useful when instances live on a separate drive or non-standard location. When unset, defaults to `<data_dir>/instances`.
 
 ## Architecture
 

--- a/src/data/app_config.rs
+++ b/src/data/app_config.rs
@@ -11,6 +11,8 @@ pub struct AppConfig {
     pub sort_ascending: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instances_dir: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -27,6 +29,7 @@ impl Default for AppConfig {
             default_sort: default_sort(),
             sort_ascending: true,
             data_dir: None,
+            instances_dir: None,
         }
     }
 }
@@ -70,6 +73,10 @@ impl AppConfig {
 
     pub fn resolved_data_dir(&self) -> Option<PathBuf> {
         self.data_dir.as_ref().map(|p| expand_tilde(p))
+    }
+
+    pub fn resolved_instances_dir(&self) -> Option<PathBuf> {
+        self.instances_dir.as_ref().map(|p| expand_tilde(p))
     }
 
     pub fn default_sort_mode(&self) -> SortMode {

--- a/src/data/config.rs
+++ b/src/data/config.rs
@@ -5,12 +5,22 @@ use std::path::{Path, PathBuf};
 
 pub struct PrismConfig {
     pub data_dir: PathBuf,
+    instances_dir_override: Option<PathBuf>,
     #[allow(dead_code)]
     pub selected_instance: Option<String>,
 }
 
 impl PrismConfig {
-    pub fn load(data_dir: &Path) -> Result<Self> {
+    pub fn load(data_dir: &Path, instances_dir_override: Option<PathBuf>) -> Result<Self> {
+        if let Some(ref dir) = instances_dir_override
+            && !dir.exists()
+        {
+            return Err(PrismError::Config(format!(
+                "Configured instances_dir does not exist: {}",
+                dir.display()
+            )));
+        }
+
         let config_path = data_dir.join("prismlauncher.cfg");
         let mut config = Ini::new();
 
@@ -25,12 +35,17 @@ impl PrismConfig {
 
         Ok(Self {
             data_dir: data_dir.to_path_buf(),
+            instances_dir_override,
             selected_instance,
         })
     }
 
     pub fn instances_dir(&self) -> PathBuf {
-        self.data_dir.join("instances")
+        if let Some(ref dir) = self.instances_dir_override {
+            dir.clone()
+        } else {
+            self.data_dir.join("instances")
+        }
     }
 
     pub fn accounts_path(&self) -> PathBuf {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
 
     let app_config = AppConfig::load();
     let data_dir = find_prism_data_dir(app_config.resolved_data_dir())?;
-    let config = PrismConfig::load(&data_dir)?;
+    let config = PrismConfig::load(&data_dir, app_config.resolved_instances_dir())?;
     let mut app = App::new(config, app_config)?;
     let mut terminal = Terminal::new()?;
     let mut events = EventStream::new(Duration::from_millis(250));


### PR DESCRIPTION
## Summary

- Adds a new `instances_dir` config option that lets users override the instances path independently of `data_dir`
- Useful when instances live on a separate drive or non-standard location
- Falls back to `<data_dir>/instances` when unset; validates the path exists on startup
- Documents the new option in the README

## Test plan

- [ ] Run without either option set — auto-detection unchanged
- [ ] Set only `instances_dir` — uses auto-detected data_dir but custom instances path
- [ ] Set both `data_dir` and `instances_dir` — each respected independently
- [ ] Set `instances_dir` to nonexistent path — app shows error
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (15/15)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Added a new `instances_dir` config option that allows users to specify a custom location for Minecraft instances independent of the main PrismLauncher `data_dir`. This is useful when instances are stored on a separate drive or non-standard location.

**Key changes:**
- Added `instances_dir` field to `AppConfig` with tilde expansion support
- Modified `PrismConfig::load()` to accept and validate the instances directory override
- Updated `instances_dir()` method to return the override path when set, otherwise falls back to `<data_dir>/instances`
- Validated that the instances directory exists during config load, returning an error if not
- Documented the new option in README with clear examples
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean implementation following existing patterns, proper validation added, well-documented, and author reports tests pass
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | documented new `instances_dir` config option with clear explanations and examples |
| src/data/app_config.rs | added `instances_dir` field with tilde expansion support matching `data_dir` pattern |
| src/data/config.rs | implemented `instances_dir` override with validation; stylistic preference for separate if statement instead of let-chain |
| src/main.rs | wired up `instances_dir` config parameter to `PrismConfig::load()` |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start[App Start] --> LoadAppConfig[Load AppConfig from config.toml]
    LoadAppConfig --> CheckDataDir{data_dir set?}
    CheckDataDir -->|Yes| ValidateDataDir[Validate data_dir exists]
    CheckDataDir -->|No| AutoDetect[Auto-detect PrismLauncher data_dir]
    ValidateDataDir --> DataDirOK[data_dir resolved]
    AutoDetect --> DataDirOK
    DataDirOK --> LoadPrismConfig[Load PrismConfig]
    LoadPrismConfig --> CheckInstancesDir{instances_dir set?}
    CheckInstancesDir -->|Yes| ValidateInstancesDir[Validate instances_dir exists]
    CheckInstancesDir -->|No| UseDefault[Use &lt;data_dir&gt;/instances]
    ValidateInstancesDir -->|Exists| InstancesDirOK[instances_dir resolved]
    ValidateInstancesDir -->|Not Found| Error1[Error: instances_dir not found]
    UseDefault --> InstancesDirOK
    InstancesDirOK --> AppReady[App Ready]
```

<sub>Last reviewed commit: 6ef7df4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->